### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,7 +95,9 @@ hf-practices/
 │       ├── CapturedListViewController.{h,m}      # Captured fugitives list
 │       └── CapturedPhotoViewController.{h,m}     # Camera photo capture
 ├── .github/
-│   └── copilot-instructions.md           # This file
+│   ├── copilot-instructions.md           # This file
+│   └── workflows/
+│       └── release.yaml                  # Tag creation on merge to main
 ├── CHANGELOG.md
 ├── CONTRIBUTING.md
 ├── LICENSE
@@ -173,7 +175,7 @@ hf-practices/
 
 ## CI/CD Pipeline
 
-There is **no CI/CD automation** in this repository. All validation is manual in Xcode on macOS.
+- **Release workflow** (`.github/workflows/release.yaml`): on push to `main`, delegates to the shared `rios0rios0/pipelines` release workflow to create Git tags. No build or test jobs — all Xcode validation remains manual on macOS.
 
 ## Development Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to document the `release.yaml` CI workflow and update the repository structure tree
+
 ## [0.1.1] - 2026-04-28
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.