### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,7 +78,7 @@ hf-practices/
 │       ├── MasterViewController.{h,m}    # Table view with drink list
 │       ├── DetailViewController.{h,m}    # Drink detail display
 │       ├── AddViewController.{h,m}       # Add/edit drink form
-│       ├── DrinkConstats.h               # Key constants (NAME_KEY, DIRECTION_KEY)
+│       ├── DrinkConstats.h               # Key constants (NAME_KEY, INGREDIENTS_KEY, DIRECTIONS_KEY)
 │       └── DrinkDirections.plist         # Drink recipe data (plist persistence)
 ├── InstaTwit/
 │   ├── InstaTwit.xcodeproj/
@@ -165,7 +165,7 @@ hf-practices/
 - Use `IBOutlet` for view references and `IBAction` for event handlers wired in Interface Builder
 - Plist persistence: load with `[NSArray arrayWithContentsOfFile:]`; save with `[array writeToFile:atomically:YES]`
 - Core Data: obtain `NSManagedObjectContext` from `AppDelegate`; create entities with `[NSEntityDescription insertNewObjectForEntityForName:inManagedObjectContext:]`
-- Constants declared in header files as `NSString * const` (e.g., `DrinkConstats.h`)
+- Constants declared in header files as `#define` macros (e.g., `DrinkConstats.h` defines `NAME_KEY`, `INGREDIENTS_KEY`, `DIRECTIONS_KEY`)
 
 ### File Organization
 
@@ -209,7 +209,7 @@ open "iBountyHunter/iBountyHunter.xcodeproj"
 ### Modifying Plist Data (DrinkMixer)
 
 1. Open `DrinkDirections.plist` in Xcode's property list editor or a text editor
-2. Each entry is a dictionary with keys `name` and `direction` (defined in `DrinkConstats.h`)
+2. Each entry is a dictionary with keys `name`, `ingredients`, and `directions` (defined in `DrinkConstats.h`)
 3. Build and run to verify data loads correctly in `MasterViewController`
 
 ### Working with Core Data (iBountyHunter)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- created `CLAUDE.md` to give Claude Code sessions repo-specific guidance (no build system, manual reference counting, per-sub-project architecture)
+
+### Changed
+
+- corrected `.github/copilot-instructions.md` DrinkMixer constants: keys are `NAME_KEY`, `INGREDIENTS_KEY`, `DIRECTIONS_KEY` (`name`/`ingredients`/`directions`) declared as `#define` macros, not `NSString * const`
+
 ## [0.1.2] - 2026-05-19
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+Five standalone iOS practice apps in Objective-C, from the "Head First iPhone and iPad Development" book: `Hello World`, `iDecide`, `DrinkMixer`, `InstaTwit`, `iBountyHunter`. Development was discontinued on 2012-02-16; the repo is a preserved historical reference. A parallel guidance file exists for GitHub Copilot at `.github/copilot-instructions.md` — keep the two consistent in substance when editing either.
+
+## Build, run, validate
+
+There is **no build system, package manager, linter, or test suite** — do not look for `make`, `npm`, CI build steps, or a `Tests/` target; none exist. Each sub-project is a self-contained Xcode project.
+
+- Build/run: open a sub-project's `.xcodeproj` in Xcode (e.g. `open "DrinkMixer/DrinkMixer.xcodeproj"`), pick an iOS Simulator target, `Cmd+B` / `Cmd+R`.
+- Validation is **manual only**: build, run on the Simulator, exercise the UI. There is nothing to run from the command line.
+- The only automation is `.github/workflows/release.yaml`, which delegates to `rios0rios0/pipelines` to cut a Git tag on push to `main`. It runs no build or test.
+
+## Conventions that differ from modern Objective-C
+
+- **Manual reference counting (MRC), not ARC.** Code uses explicit `retain`/`release`/`autorelease` and releases in `dealloc`. Do not introduce ARC syntax. Modern Xcode may prompt to migrate to ARC — that breaks these targets; the workaround is `-fno-objc-arc` / disabling ARC in Build Settings.
+- **XIB-based UI**, no programmatic layout and no storyboards. Not every controller has a XIB — e.g. `DrinkMixer/AddViewController` has none.
+- Object properties use `(nonatomic, retain)`; delegates/primitives use `(nonatomic, assign)`.
+- **`DrinkMixer/DrinkConstats.h`** — the filename is misspelled (the in-file comment reads `DrinkConstants.h`); keep the existing spelling, three sources `#import` it. It declares `#define` macros `NAME_KEY` (`@"name"`), `INGREDIENTS_KEY` (`@"ingredients"`), `DIRECTIONS_KEY` (`@"directions"`) — these are the dictionary/plist keys for every drink and for `DrinkDirections.plist`.
+
+## Architecture notes worth knowing
+
+- **DrinkMixer**: master/detail over an `NSMutableArray` of `NSDictionary` drinks; `AddViewController` is modal and returns via delegate callback; data is persisted to `DrinkDirections.plist`, saved on app termination via an `NSNotificationCenter` observer.
+- **InstaTwit**: posts via a **synchronous** `NSURLConnection sendSynchronousRequest:` to the retired Twitter v1 XML endpoint with credentials inlined in the URL. Network calls will fail today — expected, do not "fix."
+- **iBountyHunter**: Core Data stack lives in `AppDelegate`; `NSFetchedResultsController` (with a named cache) drives the fugitive and captured lists; `Fugitive` is an `NSManagedObject` that also conforms to `MKAnnotation` (MapKit), so it carries `coordinate`/`title`/`subtitle`. Camera capture is in `CapturedPhotoViewController`. The model has multiple `.xcdatamodel` versions under `iBountyHunter.xcdatamodeld/`; after a schema change, delete the app from the Simulator to drop the stale `.sqlite` store before re-running.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.