### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -122,7 +122,7 @@ hf-practices/
 ### Common Patterns Across Sub-Projects
 
 - **MVC** (Model-View-Controller): each sub-project separates view files (XIBs), controller classes (`.h`/`.m`), and data (plist or Core Data)
-- **XIB-based UI**: every `UIViewController` has a corresponding `.xib` file managed by Interface Builder; no programmatic layout
+- **XIB-based UI**: Interface Builder `.xib` files, no programmatic layout and no storyboards. Most controllers have a matching XIB, but not all — e.g. `DrinkMixer/AddViewController`, `iBountyHunter/FugitiveListViewController`, and `iBountyHunter/CapturedListViewController` have none (their UI lives in a parent XIB or is built in code)
 - **Manual memory management**: `retain`/`release`/`autorelease` calls throughout; no `@autoreleasepool` blocks or ARC syntax
 - **AppDelegate as entry point**: `application:didFinishLaunchingWithOptions:` sets up the root view controller in every sub-project
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- corrected `.github/copilot-instructions.md` XIB claim: not every `UIViewController` has a `.xib` (e.g. `DrinkMixer/AddViewController`, `iBountyHunter/FugitiveListViewController`, `iBountyHunter/CapturedListViewController` have none)
+
 ## [0.2.0] - 2026-06-03
 
 ### Added


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.